### PR TITLE
Improve encoder responsiveness by having it trigger an interrupt

### DIFF
--- a/SCTVcode/z_main.ino
+++ b/SCTVcode/z_main.ino
@@ -38,6 +38,8 @@ void setup()
 
   myusb.begin();     // start the USB device service
   readRTClocale();   // get the locale data if it was stored
+  
+  attachInterrupt(encAPin, DoEnc, CHANGE);  // Fix lack of encoder responsiveness under high load
 }
 
 


### PR DESCRIPTION
Still misses a click once in a while but nowhere near as often. Was particularly bad on the new faces/memory one